### PR TITLE
Update for Scenic v0.10, simplify the codec remove Timex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 0.10.0
+
+* Updated to work with Scenic v0.10 api
+* Dependency on Timex removed
+* Overall simplification of the clocks
+* Digital formats are now only :hours_12 and :hours_24
+
+
+## v0.7.0
+
+* First released version

--- a/lib/components.ex
+++ b/lib/components.ex
@@ -37,7 +37,6 @@ defmodule Scenic.Clock.Components do
 
   Analog clocks honor the following list of additional styles.
   * `:radius` - the radius of the clock's main circle.
-  * `:timezone` - which timezone to display the time in. Should be one of the timezones supported by the Timex Hex package. See `Timex.timezones()`. The default is whatever Timex says is the system timezone.
   * `:seconds` - `true` or `false`. Show the seconds hand. Note: Showing the seconds hand uses more energy by rendering the scene every second. The default is `false`.
   * `:ticks` - `true` or `false`. Show ticks marking the hour positions. Default is `true` if the radius is >= 30.
 
@@ -91,9 +90,7 @@ defmodule Scenic.Clock.Components do
   ### Additional Styles
 
   Digital clocks honor the following list of additional styles.
-  * `:timezone` - which timezone to display the time in. Should be one of the timezones supported by the Timex Hex package. See `Timex.timezones()`. The default is whatever Timex sais is the system timexone.
-  * `:format` - [strftime](https://www.foragoodstrftime.com/) format for the time string. Default is `"%a %l:%M %p"`.
-
+  * `:format` - `:hours_12` or `:hours_24`. The default is `:hours_12`.
 
   ## Theme
 

--- a/lib/digital.ex
+++ b/lib/digital.ex
@@ -14,20 +14,13 @@ defmodule Scenic.Clock.Digital do
   use Scenic.Component, has_children: false
 
   alias Scenic.Graph
-  # alias Scenic.Primitive.Style.Theme
-
-  # alias Scenic.Component.Input.Dropdown
+  alias Scenic.Primitive.Style.Theme
   import Scenic.Primitives, only: [{:text, 2}, {:text, 3}]
 
-  # import IEx
-
   # formats setup
-  @default_format "%a %l:%M %p"
+  @default_format :hours_12
 
-  @default_timezone "GMT"
-
-  # theme
-  # @default_theme    :dark
+  @default_theme :dark
 
   # --------------------------------------------------------
   @doc false
@@ -39,40 +32,27 @@ defmodule Scenic.Clock.Digital do
   def init(_, opts) do
     styles = opts[:styles]
 
-    # get the timezone
-    timezone =
-      case Enum.member?(Timex.timezones(), styles[:timezone]) do
-        true -> styles[:timezone]
-        false -> Timex.Timezone.local() || @default_timezone
-      end
+    # theme is passed in as an inherited style
+    theme =
+      (styles[:theme] || Theme.preset(@default_theme))
+      |> Theme.normalize()
 
-    # get and validate the requested time format
     format =
       case styles[:format] do
-        format when is_bitstring(format) ->
-          # doubleck check that is is a valid
-          Timex.now(timezone)
-          |> Timex.format(format, :strftime)
-          |> case do
-            {:ok, _} -> format
-            _ -> @default_format
-          end
-
-        _ ->
-          @default_format
+        :hours_12 -> :hours_12
+        :hours_24 -> :hours_24
+        _ -> @default_format
       end
 
     # set up the requested graph
     graph =
       Graph.build(styles: styles)
-      # |> text("", fill: theme.text, id: :time)
-      |> text("", id: :time)
+      |> text("", id: :time, fill: theme.text)
 
-    state =
+    {state, graph} =
       %{
         graph: graph,
         format: format,
-        timezone: timezone,
         timer: nil,
         last: nil,
         seconds: !!styles[:seconds]
@@ -89,7 +69,7 @@ defmodule Scenic.Clock.Digital do
     {microseconds, _} = Time.utc_now().microsecond
     Process.send_after(self(), :start_clock, 1001 - trunc(microseconds / 1000))
 
-    {:ok, state}
+    {:ok, state, push: graph}
   end
 
   # --------------------------------------------------------
@@ -97,46 +77,66 @@ defmodule Scenic.Clock.Digital do
   # should be shortly after the actual one-second mark
   def handle_info(:start_clock, state) do
     # start the timer on a one-second interval
-    {:ok, timer} = :timer.send_interval(1000, :second)
+    {:ok, timer} = :timer.send_interval(1000, :tick_tock)
 
     # update the clock
-    state = update_time(state)
-
-    {:noreply, %{state | timer: timer}}
+    {state, graph} = update_time(state)
+    {:noreply, %{state | timer: timer}, push: graph}
   end
 
   # --------------------------------------------------------
-  def handle_info(:second, state) do
-    {:noreply, update_time(state)}
-  end
-
-  # --------------------------------------------------------
-  defp squash(string) do
-    string
-    |> String.trim()
-    |> String.replace(~r/\s{2,}/, " ")
+  def handle_info(:tick_tock, state) do
+    {state, graph} = update_time(state)
+    {:noreply, state, push: graph}
   end
 
   # --------------------------------------------------------
   defp update_time(
          %{
            format: format,
+           seconds: seconds,
            graph: graph,
-           timezone: timezone,
            last: last
          } = state
        ) do
-    {:ok, time} =
-      Timex.now(timezone)
-      |> Timex.format(format, :strftime)
+    time = :calendar.local_time()
+    base_time = base_time(time, seconds)
 
-    time = squash(time)
+    case base_time != last do
+      true ->
+        graph = Graph.modify(graph, :time, &text(&1, format_time(time, format, seconds)))
+        {%{state | last: base_time}, graph}
 
-    if time != last do
-      Graph.modify(graph, :time, &text(&1, time))
-      |> push_graph()
+      _ ->
+        {state, nil}
     end
-
-    %{state | last: time}
   end
+
+  # --------------------------------------------------------
+  defp format_time({_, {h, m, s}}, :hours_12, seconds) do
+    {h, am_pm} =
+      cond do
+        h > 12 -> {h - 12, "PM"}
+        true -> {h, "AM"}
+      end
+
+    case seconds do
+      true -> "#{h}:#{format_ms(m)}:#{format_ms(s)} #{am_pm}"
+      false -> "#{h}:#{format_ms(m)} #{am_pm}"
+    end
+  end
+
+  defp format_time({_, {h, m, s}}, :hours_24, seconds) do
+    case seconds do
+      true -> "#{h}:#{format_ms(m)}:#{format_ms(s)}"
+      false -> "#{h}:#{format_ms(m)}"
+    end
+  end
+
+  defp format_ms(m) when m >= 0 and m < 10, do: "0#{m}"
+  defp format_ms(m), do: to_string(m)
+
+  # --------------------------------------------------------
+  defp base_time(time, true), do: time
+  defp base_time({d, {h, m, _}}, false), do: {d, {h, m}}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Scenic.Clock.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.10.0"
   @github "https://github.com/boydm/scenic_clock"
 
   def project do
@@ -36,8 +36,8 @@ defmodule Scenic.Clock.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:scenic, "~> 0.8"},
-      {:timex, "~> 3.3"},
+      # {:scenic, "~> 0.10"},
+      {:scenic, git: "https://github.com/boydm/scenic.git"},
       {:ex_doc, ">= 0.0.0", only: [:dev, :docs]}
     ]
   end

--- a/test/clock_analog_test.exs
+++ b/test/clock_analog_test.exs
@@ -1,0 +1,31 @@
+#
+#  Created by Boyd Multerer on 23/03/2019.
+#  Copyright © 2019 Kry10 Industries. All rights reserved.
+#
+
+defmodule Scenic.Clock.AnalogTest do
+  use ExUnit.Case, async: true
+  doctest Scenic.Scenes.Error
+
+  @state %{
+    graph: Scenic.Graph.build(),
+    timer: nil,
+    last: nil,
+    seconds: true
+  }
+
+  test "init" do
+    {:ok, _, push: _} =
+      Scenic.Clock.Analog.init( nil, styles: %{} )
+  end
+
+  test "handle_info start_clock" do
+    {:noreply, state, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+    assert state.timer
+  end
+
+  test "handle_info tick_tock" do
+    {:noreply, _, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+  end
+
+end

--- a/test/clock_analog_test.exs
+++ b/test/clock_analog_test.exs
@@ -15,17 +15,15 @@ defmodule Scenic.Clock.AnalogTest do
   }
 
   test "init" do
-    {:ok, _, push: _} =
-      Scenic.Clock.Analog.init( nil, styles: %{} )
+    {:ok, _, push: _} = Scenic.Clock.Analog.init(nil, styles: %{})
   end
 
   test "handle_info start_clock" do
-    {:noreply, state, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+    {:noreply, state, push: _} = Scenic.Clock.Analog.handle_info(:start_clock, @state)
     assert state.timer
   end
 
   test "handle_info tick_tock" do
-    {:noreply, _, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+    {:noreply, _, push: _} = Scenic.Clock.Analog.handle_info(:start_clock, @state)
   end
-
 end

--- a/test/clock_digital_test.exs
+++ b/test/clock_digital_test.exs
@@ -16,17 +16,15 @@ defmodule Scenic.Clock.DigitalTest do
   }
 
   test "init" do
-    {:ok, _, push: _} =
-      Scenic.Clock.Analog.init( nil, styles: %{} )
+    {:ok, _, push: _} = Scenic.Clock.Analog.init(nil, styles: %{})
   end
 
   test "handle_info start_clock" do
-    {:noreply, state, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+    {:noreply, state, push: _} = Scenic.Clock.Analog.handle_info(:start_clock, @state)
     assert state.timer
   end
 
   test "handle_info tick_tock" do
-    {:noreply, _, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+    {:noreply, _, push: _} = Scenic.Clock.Analog.handle_info(:start_clock, @state)
   end
-
 end

--- a/test/clock_digital_test.exs
+++ b/test/clock_digital_test.exs
@@ -1,0 +1,32 @@
+#
+#  Created by Boyd Multerer on 23/03/2019.
+#  Copyright © 2019 Kry10 Industries. All rights reserved.
+#
+
+defmodule Scenic.Clock.DigitalTest do
+  use ExUnit.Case, async: true
+  doctest Scenic.Scenes.Error
+
+  @state %{
+    graph: Scenic.Graph.build(),
+    format: :hours_12,
+    timer: nil,
+    last: nil,
+    seconds: true
+  }
+
+  test "init" do
+    {:ok, _, push: _} =
+      Scenic.Clock.Analog.init( nil, styles: %{} )
+  end
+
+  test "handle_info start_clock" do
+    {:noreply, state, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+    assert state.timer
+  end
+
+  test "handle_info tick_tock" do
+    {:noreply, _, push: _} = Scenic.Clock.Analog.handle_info( :start_clock, @state )
+  end
+
+end


### PR DESCRIPTION
Updated to follow the Scenic v0.10 return pattern
Code is overall simplified.
Timex was overkill for this use case, so it has been removed.
